### PR TITLE
Method added to get queued log events

### DIFF
--- a/log4javascript_uncompressed.js
+++ b/log4javascript_uncompressed.js
@@ -4829,6 +4829,9 @@
 				}
 			};
 
+			this.getQueuedLoggingEvents = function() {
+				return queuedLoggingEvents;
+			};
 			var appendQueuedLoggingEvents = function() {
 				while (queuedLoggingEvents.length > 0) {
 					queuedLoggingEvents.shift().append();


### PR DESCRIPTION
Method added to get queued logging events. I need this method to get the queued log events when the log4javascript is closed, but the website user has requested to send the queued logs to a specific 3rd party log system